### PR TITLE
Reduced API calls significantly

### DIFF
--- a/cmd/sync/Godeps/Godeps.json
+++ b/cmd/sync/Godeps/Godeps.json
@@ -119,16 +119,6 @@
 			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
-			"ImportPath": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"Comment": "v1.6.15-1-gb84b5a4",
-			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
-		},
-		{
-			"ImportPath": "github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface",
-			"Comment": "v1.6.15-1-gb84b5a4",
-			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
-		},
-		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ec2",
 			"Comment": "v1.6.15-1-gb84b5a4",
 			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"

--- a/cmd/sync/aws.go
+++ b/cmd/sync/aws.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
@@ -13,31 +11,36 @@ import (
 // AWSClient allows you to get the list of IP addresses of instanes of an Auto Scaling group
 type AWSClient struct {
 	svcEC2         ec2iface.EC2API
-	svcAutoscaling autoscalingiface.AutoScalingAPI
 }
 
 // NewAWSClient creates an AWSClient
-func NewAWSClient(svcEC2 ec2iface.EC2API, svcAutoscaling autoscalingiface.AutoScalingAPI) *AWSClient {
-	return &AWSClient{svcEC2, svcAutoscaling}
-}
-
-// CheckIfAutoscalingGroupExists checks if the Auto Scaling group exists
-func (client *AWSClient) CheckIfAutoscalingGroupExists(name string) (bool, error) {
-	_, exists, err := client.getAutoscalingGroup(name)
-	return exists, err
+func NewAWSClient(svcEC2 ec2iface.EC2API) *AWSClient {
+	return &AWSClient{svcEC2,}
 }
 
 // GetPrivateIPsOfInstancesOfAutoscalingGroup returns the list of IP addresses of instanes of the Auto Scaling group
 func (client *AWSClient) GetPrivateIPsOfInstancesOfAutoscalingGroup(name string) ([]string, error) {
-	group, exists, err := client.getAutoscalingGroup(name)
+	params := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("tag:aws:autoscaling:groupName"),
+				Values: []*string{
+					aws.String(name),
+				},
+			},
+		},
+	}
+	resverations, err := client.svcEC2.DescribeInstances(params)
+
 	if err != nil {
 		return nil, err
 	}
-	if !exists {
+	if len(resverations.Reservations) == 0 {
 		return nil, fmt.Errorf("autoscaling group %v doesn't exists", name)
 	}
 
-	instances, err := client.getInstancesOfAutoscalingGroup(group)
+	instances, err := client.getInstancesOfResverations(resverations)
+
 	if err != nil {
 		return nil, err
 	}
@@ -52,45 +55,15 @@ func (client *AWSClient) GetPrivateIPsOfInstancesOfAutoscalingGroup(name string)
 	return result, nil
 }
 
-func (client *AWSClient) getAutoscalingGroup(name string) (*autoscaling.Group, bool, error) {
-	params := &autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{
-			aws.String(name),
-		},
-	}
 
-	resp, err := client.svcAutoscaling.DescribeAutoScalingGroups(params)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if len(resp.AutoScalingGroups) != 1 {
-		return nil, false, nil
-	}
-
-	return resp.AutoScalingGroups[0], true, nil
-}
-
-func (client *AWSClient) getInstancesOfAutoscalingGroup(group *autoscaling.Group) ([]*ec2.Instance, error) {
+func (client *AWSClient) getInstancesOfResverations(group *ec2.DescribeInstancesOutput) ([]*ec2.Instance, error) {
 	var result []*ec2.Instance
 
-	if len(group.Instances) == 0 {
+	if len(group.Reservations) == 0 {
 		return result, nil
 	}
 
-	var ids []*string
-	for _, ins := range group.Instances {
-		ids = append(ids, ins.InstanceId)
-	}
-	params := &ec2.DescribeInstancesInput{
-		InstanceIds: ids,
-	}
-
-	resp, err := client.svcEC2.DescribeInstances(params)
-	if err != nil {
-		return result, err
-	}
-	for _, res := range resp.Reservations {
+	for _, res := range group.Reservations {
 		for _, ins := range res.Instances {
 			result = append(result, ins)
 		}

--- a/cmd/sync/aws.go
+++ b/cmd/sync/aws.go
@@ -39,7 +39,7 @@ func (client *AWSClient) GetPrivateIPsOfInstancesOfAutoscalingGroup(name string)
 		return nil, fmt.Errorf("autoscaling group %v doesn't exists", name)
 	}
 
-	instances, err := client.getInstancesOfResverations(resverations)
+	instances, err := client.getInstancesOfReservations(resverations)
 
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func (client *AWSClient) GetPrivateIPsOfInstancesOfAutoscalingGroup(name string)
 }
 
 
-func (client *AWSClient) getInstancesOfResverations(group *ec2.DescribeInstancesOutput) ([]*ec2.Instance, error) {
+func (client *AWSClient) getInstancesOfReservations(group *ec2.DescribeInstancesOutput) ([]*ec2.Instance, error) {
 	var result []*ec2.Instance
 
 	if len(group.Reservations) == 0 {

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -19,7 +19,7 @@ import (
 
 var configFile = flag.String("config_path", "/etc/nginx/aws.yaml", "Path to the config file")
 var logFile = flag.String("log_path", "", "Path to the log file. If the file doesn't exist, it will be created")
-var version = "0.1-2"
+var version = "0.2-0"
 
 const connTimeoutInSecs = 10
 

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
@@ -68,13 +67,6 @@ func main() {
 			log.Printf("Problem with the NGINX configuration: %v", err)
 			os.Exit(10)
 		}
-		exists, err := awsClient.CheckIfAutoscalingGroupExists(ups.AutoscalingGroup)
-		if err != nil {
-			log.Printf("Couldn't check if an Auto Scaling group exists: %v", err)
-			os.Exit(10)
-		} else if !exists {
-			log.Printf("Warning: Auto Scaling group %v doesn't exists", ups.AutoscalingGroup)
-		}
 	}
 
 	sigterm := make(chan os.Signal, 1)
@@ -123,7 +115,6 @@ func createAWSClient(region string) *AWSClient {
 	httpClient := &http.Client{Timeout: connTimeoutInSecs * time.Second}
 	cfg := &aws.Config{Region: aws.String(region), HTTPClient: httpClient}
 	session := session.New(cfg)
-	svcAutoscaling := autoscaling.New(session)
 	svcEC2 := ec2.New(session)
-	return NewAWSClient(svcEC2, svcAutoscaling)
+	return NewAWSClient(svcEC2)
 }


### PR DESCRIPTION
Using the ASG tag on EC2 instances instead of enumerating them by the ASG API