### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO_DOCKER_RUN = docker run --rm -v $(shell pwd):/go/src/github.com/nginxinc/ngin
 GOLANG_CONTAINER = golang:1.10
 BUILD_IN_CONTAINER = 1
 
-all: amazon centos7 ubuntu-trusty ubuntu-xenial
+all: amazon centos7 ubuntu-trusty ubuntu-xenial amazon2
 
 test:
 ifeq ($(BUILD_IN_CONTAINER),1)
@@ -21,6 +21,10 @@ endif
 amazon: compile
 	make -C build/package/builders/amazon/
 	docker run --rm -v $(shell pwd)/build/package/rpm:/rpm -v $(shell pwd)/build_output:/build_output amazon-builder
+
+amazon2: compile
+	make -C build/package/builders/amazon2/
+	docker run --rm -v $(shell pwd)/build/package/rpm:/rpm -v $(shell pwd)/build_output:/build_output amazon2-builder
 
 centos7: compile
 	make -C build/package/builders/centos7/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We provide packages for the following operating systems:
 
 * Ubuntu: 14.04 (Trusty), 16.04 (Xenial)
 * CentOS/RHEL: 7
-* Amazon Linux
+* Amazon Linux: 1, 2
 
 Support for other operating systems can be added.
 
@@ -146,9 +146,9 @@ upstreams:
 
 nginx-asg-sync runs as a system service and supports the start/stop/restart commands.
 
-For Ubuntu 14.04 and Amazon Linux, run: `$ sudo start|stop|restart nginx-asg-sync`
+For Ubuntu 14.04 and Amazon Linux 1, run: `$ sudo start|stop|restart nginx-asg-sync`
 
-For Ubuntu 16.04 and CentOS7/RHEL7, run: `$ sudo service nginx-asg-sync start|stop|restart`
+For Ubuntu 16.04, CentOS7/RHEL7 and Amazon Linux 2, run: `$ sudo service nginx-asg-sync start|stop|restart`
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ You can compile nginx-asg-sync and build a software package using the provided M
 
 To build a software package, run: `$ make <os>`
 where `<os>` is the target OS. The following values are allowed:
-* `amazon` for Amazon Linux
+* `amazon` for Amazon Linux 1
+* `amazon2` for Amazon Linux 2
 * `centos7` for CentOS7/RHEL7
 * `ubuntu-trusty` for Ubuntu 14.04
 * `ubuntu-xenial` for Ubuntu 16.04

--- a/build/package/builders/amazon2/Dockerfile
+++ b/build/package/builders/amazon2/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:1
+FROM amazonlinux:2
 
 RUN yum install -y rpmdevtools
 ADD build.sh /

--- a/build/package/builders/amazon2/Makefile
+++ b/build/package/builders/amazon2/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build -t amazon2-builder .

--- a/build/package/builders/amazon2/build.sh
+++ b/build/package/builders/amazon2/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p ~/rpmbuild
+cp -r rpm/* ~/rpmbuild/
+rpmbuild -bb ~/rpmbuild/SPECS/nginx-asg-sync.spec
+cp ~/rpmbuild/RPMS/x86_64/*.rpm /build_output


### PR DESCRIPTION
This change will address the following isssue:
https://github.com/nginxinc/nginx-asg-sync/issues/17

### Proposed changes
Add a builder for Amazon Linux 2
Update the documentation to reflect the new builder.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-asg-sync/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
