### PR TITLE
Make code cloud agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,19 @@ Below you will find documentation on how to use nginx-asg-sync.
 **Note:** the documentation for **the latest stable release** is available via a link in the description of the release. See the [releases page](https://github.com/nginxinc/nginx-asg-sync/releases).
 
 **Contents:**
-- [Supported Operating Systems](#supported-operating-systems)
-- [Setting up Access to the AWS API](#setting-up-access-to-the-aws-api)
-- [Installation](#installation)
-- [Configuration](#configuration)
-  - [NGINX Plus Configuration](#nginx-plus-configuration)
-  - [nginx-asg-sync Configuration](#nginx-asg-sync-configuration)
-- [Usage](#usage)
-- [Troubleshooting](#troubleshooting)
-- [Building a Software Package](#building-a-software-package)
-- [Support](#support)
+- [NGINX Plus Integration with AWS Auto Scaling groups -- nginx-asg-sync](#nginx-plus-integration-with-aws-auto-scaling-groups----nginx-asg-sync)
+  - [How It Works](#how-it-works)
+  - [Documentation](#documentation)
+  - [Supported Operating Systems](#supported-operating-systems)
+  - [Setting up Access to the AWS API](#setting-up-access-to-the-aws-api)
+  - [Installation](#installation)
+  - [Configuration](#configuration)
+    - [NGINX Plus Configuration](#nginx-plus-configuration)
+    - [nginx-asg-sync Configuration](#nginx-asg-sync-configuration)
+  - [Usage](#usage)
+  - [Troubleshooting](#troubleshooting)
+  - [Building a Software Package](#building-a-software-package)
+  - [Support](#support)
 
 ## Supported Operating Systems
 
@@ -122,6 +125,7 @@ nginx-asg-sync is configured in **/etc/nginx/aws.yaml**. For our example, we def
 region: us-west-2
 api_endpoint: http://127.0.0.1:8080/api
 sync_interval_in_seconds: 5
+cloud_provider: AWS
 upstreams:
  - name: backend-one
    autoscaling_group: backend-one-group
@@ -136,6 +140,7 @@ upstreams:
 * The `region` key defines the AWS region where we deploy NGINX Plus and the Auto Scaling groups.
 * The `api_endpoint` key defines the NGINX Plus API endpoint.
 * The `sync_interval_in_seconds` key defines the synchronization interval: nginx-asg-sync checks for scaling updates every 5 seconds.
+* The `cloud_provider` key defines a cloud provider that will be used. The default is `AWS`. This means the key can be empty if using AWS.
 * The `upstreams` key defines the list of upstream groups. For each upstream group we specify:
   * `name` – The name we specified for the upstream block in the NGINX Plus configuration.
   * `autoscaling_group` – The name of the corresponding Auto Scaling group.

--- a/cmd/sync/aws_test.go
+++ b/cmd/sync/aws_test.go
@@ -1,0 +1,75 @@
+package main
+
+import "testing"
+
+type testInputAWS struct {
+	cfg *awsConfig
+	msg string
+}
+
+func getValidAWSConfig() *awsConfig {
+	upstreams := []awsUpstream{
+		{
+			Name:             "backend1",
+			AutoscalingGroup: "backend-group",
+			Port:             80,
+			Kind:             "http",
+		},
+	}
+	cfg := awsConfig{
+		Region:    "us-west-2",
+		Upstreams: upstreams,
+	}
+
+	return &cfg
+}
+
+func getInvalidAWSConfigInput() []*testInputAWS {
+	var input []*testInputAWS
+
+	invalidRegionCfg := getValidAWSConfig()
+	invalidRegionCfg.Region = ""
+	input = append(input, &testInputAWS{invalidRegionCfg, "invalid region"})
+
+	invalidMissingUpstreamsCfg := getValidAWSConfig()
+	invalidMissingUpstreamsCfg.Upstreams = nil
+	input = append(input, &testInputAWS{invalidMissingUpstreamsCfg, "no upstreams"})
+
+	invalidUpstreamNameCfg := getValidAWSConfig()
+	invalidUpstreamNameCfg.Upstreams[0].Name = ""
+	input = append(input, &testInputAWS{invalidUpstreamNameCfg, "invalid name of the upstream"})
+
+	invalidUpstreamAutoscalingGroupCfg := getValidAWSConfig()
+	invalidUpstreamAutoscalingGroupCfg.Upstreams[0].AutoscalingGroup = ""
+	input = append(input, &testInputAWS{invalidUpstreamAutoscalingGroupCfg, "invalid autoscaling_group of the upstream"})
+
+	invalidUpstreamPortCfg := getValidAWSConfig()
+	invalidUpstreamPortCfg.Upstreams[0].Port = 0
+	input = append(input, &testInputAWS{invalidUpstreamPortCfg, "invalid port of the upstream"})
+
+	invalidUpstreamKindCfg := getValidAWSConfig()
+	invalidUpstreamKindCfg.Upstreams[0].Kind = ""
+	input = append(input, &testInputAWS{invalidUpstreamKindCfg, "invalid kind of the upstream"})
+
+	return input
+}
+
+func TestValidateAWSConfigNotValid(t *testing.T) {
+	input := getInvalidAWSConfigInput()
+
+	for _, item := range input {
+		err := validateAWSConfig(item.cfg)
+		if err == nil {
+			t.Errorf("validateAWSConfig() didn't fail for the invalid config file with %v", item.msg)
+		}
+	}
+}
+
+func TestValidateAWSConfigValid(t *testing.T) {
+	cfg := getValidAWSConfig()
+
+	err := validateAWSConfig(cfg)
+	if err != nil {
+		t.Errorf("validateAWSConfig() failed for the valid config: %v", err)
+	}
+}

--- a/cmd/sync/config.go
+++ b/cmd/sync/config.go
@@ -4,37 +4,29 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
-type config struct {
-	Region                string
+// commonConfig stores the configuration parameters common to all providers
+type commonConfig struct {
 	APIEndpoint           string        `yaml:"api_endpoint"`
 	SyncIntervalInSeconds time.Duration `yaml:"sync_interval_in_seconds"`
-	Upstreams             []upstream
-}
-
-type upstream struct {
-	Name             string
-	AutoscalingGroup string `yaml:"autoscaling_group"`
-	Port             int
-	Kind             string
+	CloudProvider         string        `yaml:"cloud_provider"`
 }
 
 const errorMsgFormat = "The mandatory field %v is either empty or missing in the config file"
 const intervalErrorMsg = "The mandatory field sync_interval_in_seconds is either 0 or missing in the config file"
-const upstreamNameErrorMsg = "The mandatory field name is either empty or missing for an upstream in the config file"
-const upstreamErrorMsgFormat = "The mandatory field %v is either empty or missing for the upstream %v in the config file"
-const upstreamPortErrorMsgFormat = "The mandatory field port is either zero or missing for the upstream %v in the config file"
-const upstreamKindErrorMsgFormat = "The mandatory field kind is either not equal to http or tcp or missing for the upstream %v in the config file"
+const cloudProviderErrorMsg = "The field cloud_provider has invalid value %v in the config file"
+const defaultCloudProvider = "AWS"
 
-func parseConfig(data []byte) (*config, error) {
-	cfg, err := unmarshalConfig(data)
+func parseCommonConfig(data []byte) (*commonConfig, error) {
+	cfg := &commonConfig{}
+	err := yaml.Unmarshal(data, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateConfig(cfg)
+	err = validateCommonConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -42,46 +34,30 @@ func parseConfig(data []byte) (*config, error) {
 	return cfg, nil
 }
 
-func unmarshalConfig(data []byte) (*config, error) {
-	cfg := config{}
-
-	err := yaml.Unmarshal(data, &cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &cfg, nil
-}
-
-func validateConfig(cfg *config) error {
-	if cfg.Region == "" {
-		return fmt.Errorf(errorMsgFormat, "region")
-	}
+func validateCommonConfig(cfg *commonConfig) error {
 	if cfg.APIEndpoint == "" {
 		return fmt.Errorf(errorMsgFormat, "api_endpoint")
 	}
+
 	if cfg.SyncIntervalInSeconds == 0 {
 		return fmt.Errorf(intervalErrorMsg)
 	}
 
-	if len(cfg.Upstreams) == 0 {
-		return fmt.Errorf("There is no upstreams found in the config file")
+	if cfg.CloudProvider == "" {
+		cfg.CloudProvider = defaultCloudProvider
 	}
 
-	for _, ups := range cfg.Upstreams {
-		if ups.Name == "" {
-			return fmt.Errorf(upstreamNameErrorMsg)
-		}
-		if ups.AutoscalingGroup == "" {
-			return fmt.Errorf(upstreamErrorMsgFormat, "autoscaling_group", ups.Name)
-		}
-		if ups.Port == 0 {
-			return fmt.Errorf(upstreamPortErrorMsgFormat, ups.Name)
-		}
-		if ups.Kind == "" || !(ups.Kind == "http" || ups.Kind == "stream") {
-			return fmt.Errorf(upstreamKindErrorMsgFormat, ups.Name)
-		}
+	if !validateCloudProvider(cfg.CloudProvider) {
+		return fmt.Errorf(cloudProviderErrorMsg, cfg.CloudProvider)
 	}
 
 	return nil
+}
+
+// Upstream is the cloud agnostic representation of an Upstream (eg, common fields for every cloud provider)
+type Upstream struct {
+	Name         string
+	Port         int
+	ScalingGroup string
+	Kind         string
 }

--- a/cmd/sync/config_test.go
+++ b/cmd/sync/config_test.go
@@ -2,105 +2,61 @@ package main
 
 import "testing"
 
-var validYaml = []byte(`region: us-west-2
+var validYaml = []byte(`
+cloud_provider: AWS
 api_endpoint: http://127.0.0.1:8080/api
 sync_interval_in_seconds: 5
-upstreams:
-  - name: backend1
-    autoscaling_group: backend-group
-    port: 80
-    kind: http
-  - name: backend2
-    autoscaling_group: backend-group
-    port: 80
-    kind: http
 `)
 
-type testInput struct {
-	cfg *config
+type testInputCommon struct {
+	cfg *commonConfig
 	msg string
 }
 
-func getValidConfig() *config {
-	upstreams := []upstream{
-		{
-			Name:             "backend1",
-			AutoscalingGroup: "backend-group",
-			Port:             80,
-			Kind:             "http",
-		},
-	}
-	cfg := config{
-		Region:                "us-west-2",
+func getValidCommonConfig() *commonConfig {
+	return &commonConfig{
 		APIEndpoint:           "http://127.0.0.1:8080/api",
 		SyncIntervalInSeconds: 1,
-		Upstreams:             upstreams,
 	}
-
-	return &cfg
 }
 
-func getInvalidConfigInput() []*testInput {
-	var input []*testInput
+func getInvalidCommonConfigInput() []*testInputCommon {
+	var input []*testInputCommon
 
-	invalidRegionCfg := getValidConfig()
-	invalidRegionCfg.Region = ""
-	input = append(input, &testInput{invalidRegionCfg, "invalid region"})
-
-	invalidAPIEndpointCfg := getValidConfig()
+	invalidAPIEndpointCfg := getValidCommonConfig()
 	invalidAPIEndpointCfg.APIEndpoint = ""
-	input = append(input, &testInput{invalidAPIEndpointCfg, "invalid api_endpoint"})
+	input = append(input, &testInputCommon{invalidAPIEndpointCfg, "invalid api_endpoint"})
 
-	invalidSyncIntervalInSecondsCfg := getValidConfig()
+	invalidSyncIntervalInSecondsCfg := getValidCommonConfig()
 	invalidSyncIntervalInSecondsCfg.SyncIntervalInSeconds = 0
-	input = append(input, &testInput{invalidSyncIntervalInSecondsCfg, "invalid sync_interval_in_seconds"})
-
-	invalidMissingUpstreamsCfg := getValidConfig()
-	invalidMissingUpstreamsCfg.Upstreams = nil
-	input = append(input, &testInput{invalidMissingUpstreamsCfg, "no upstreams"})
-
-	invalidUpstreamNameCfg := getValidConfig()
-	invalidUpstreamNameCfg.Upstreams[0].Name = ""
-	input = append(input, &testInput{invalidUpstreamNameCfg, "invalid name of the upstream"})
-
-	invalidUpstreamAutoscalingGroupCfg := getValidConfig()
-	invalidUpstreamAutoscalingGroupCfg.Upstreams[0].AutoscalingGroup = ""
-	input = append(input, &testInput{invalidUpstreamAutoscalingGroupCfg, "invalid autoscaling_group of the upstream"})
-
-	invalidUpstreamPortCfg := getValidConfig()
-	invalidUpstreamPortCfg.Upstreams[0].Port = 0
-	input = append(input, &testInput{invalidUpstreamPortCfg, "invalid port of the upstream"})
-
-	invalidUpstreamKindCfg := getValidConfig()
-	invalidUpstreamKindCfg.Upstreams[0].Kind = ""
-	input = append(input, &testInput{invalidUpstreamKindCfg, "invalid kind of the upstream"})
+	input = append(input, &testInputCommon{invalidSyncIntervalInSecondsCfg, "invalid sync_interval_in_seconds"})
 
 	return input
 }
 
-func TestUnmarshalConfig(t *testing.T) {
-	_, err := unmarshalConfig(validYaml)
-	if err != nil {
-		t.Errorf("unmarshalConfig() failed for the valid yaml: %v", err)
-	}
-}
-
-func TestValidateConfigNotValid(t *testing.T) {
-	input := getInvalidConfigInput()
+func TestValidateCommonConfigNotValid(t *testing.T) {
+	input := getInvalidCommonConfigInput()
 
 	for _, item := range input {
-		err := validateConfig(item.cfg)
+		err := validateCommonConfig(item.cfg)
 		if err == nil {
-			t.Errorf("validateConfig() didn't fail for the invalid config file with %v", item.msg)
+			t.Errorf("validateCommonConfig() didn't fail for the invalid config file with %v", item.msg)
 		}
 	}
 }
 
-func TestValidateConfigValid(t *testing.T) {
-	cfg := getValidConfig()
+func TestValidateCommonConfigValid(t *testing.T) {
+	cfg := getValidCommonConfig()
 
-	err := validateConfig(cfg)
+	err := validateCommonConfig(cfg)
 	if err != nil {
-		t.Errorf("validateConfig() failed for the valid config: %v", err)
+		t.Errorf("validateCommonConfig() failed for the valid config: %v", err)
+	}
+}
+
+func TestParseCommonConfig(t *testing.T) {
+	_, err := parseCommonConfig(validYaml)
+	if err != nil {
+		t.Errorf("parseCommonConfig() failed for the valid config yaml: %v", string(validYaml))
 	}
 }

--- a/cmd/sync/provider.go
+++ b/cmd/sync/provider.go
@@ -1,0 +1,16 @@
+package main
+
+// CloudProvider is the interface to connect with any cloud provider.
+type CloudProvider interface {
+	GetPrivateIPsForScalingGroup(name string) ([]string, error)
+	CheckIfScalingGroupExists(name string) (bool, error)
+	GetUpstreams() []Upstream
+}
+
+func validateCloudProvider(provider string) bool {
+	providers := map[string]bool{
+		"AWS": true,
+	}
+
+	return providers[provider]
+}

--- a/cmd/sync/provider_test.go
+++ b/cmd/sync/provider_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestValidateCloudProviderValid(t *testing.T) {
+	provider := "AWS"
+	valid := validateCloudProvider(provider)
+	if !valid {
+		t.Errorf("validateCloudProvider(%v) returned invalid for a valid case", provider)
+	}
+}
+
+func TestValidateCloudProviderInvalid(t *testing.T) {
+	provider := "invalid"
+	valid := validateCloudProvider(provider)
+	if valid {
+		t.Errorf("validateCloudProvider(%v) returned valid for an invalid case", provider)
+	}
+}


### PR DESCRIPTION
### Proposed changes

Make the agent code cloud agnostic:
* Create a CloudProvider interface with the needed functions to work in the main loop
* Configuration will be the same for AWS. Future providers might differ, but because we have a new `Upstream` struct in common for all providers, we just need to transform the data.
* Make every cloud provider to auto check configuration file, configure itself (check cloud scaling groups, save config, etc)
* Change all the `AutoScalingGroup` for `ScalingGroup` in the code (this doesn't affect configs or docs) for simplicity (AutoScalingGroups are just from amazon. Azure groups are called VirtualMachineScaleSets.)
* Change the old code and make `awsClient` to implement the `CloudProvider` interface.
* Added a new parameter `cloudProvider`. By default is `AWS` so nothing will change in the way the agent is configured for AWS right now. When more cloud providers are added, we can add this to the documentation.


As part of the e2e test with aws (and future cloud providers) integration tests will be added. However, it might make sense to add unit testing to the providers in another PR? ❓ Right now there are no tests for that (we can use mocks for those) Let me know your thoughts.
