### PR TITLE
Update Go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services:
 - docker
 go:
-- "1.12"
+- "1.13"
 script:
 - echo "Nginx ASG sync - commit:${TRAVIS_COMMIT}"
 - make BUILD_IN_CONTAINER=0 all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO_DOCKER_RUN = docker run --rm -v $(shell pwd):/go/src/github.com/nginxinc/nginx-asg-sync -v $(shell pwd)/build_output:/build_output -w /go/src/github.com/nginxinc/nginx-asg-sync/cmd/sync
-GOLANG_CONTAINER = golang:1.12
+GOLANG_CONTAINER = golang:1.13
 BUILD_IN_CONTAINER = 1
 
 all: amazon centos7 ubuntu-xenial amazon2 ubuntu-bionic


### PR DESCRIPTION
### Proposed changes
Go 1.13 was released recently.
We need to update our projects to use Go 1.13
Make sure both travis files (if present) and Makefiles are updated.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-asg-sync/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
