### PR TITLE
Fix Upstream parameters and use default ones if not present

### DIFF
--- a/cmd/sync/aws.go
+++ b/cmd/sync/aws.go
@@ -61,16 +61,16 @@ func NewAWSClient(data []byte) (*AWSClient, error) {
 // GetUpstreams returns the Upstreams list
 func (client *AWSClient) GetUpstreams() []Upstream {
 	var upstreams []Upstream
-	for _, awsU := range client.config.Upstreams {
+	for i := 0; i < len(client.config.Upstreams); i++ {
 		u := Upstream{
-			Name:         awsU.Name,
-			Port:         awsU.Port,
-			Kind:         awsU.Kind,
-			ScalingGroup: awsU.AutoscalingGroup,
-			MaxConns:     &awsU.MaxConns,
-			MaxFails:     &awsU.MaxFails,
-			FailTimeout:  awsU.FailTimeout,
-			SlowStart:    awsU.SlowStart,
+			Name:         client.config.Upstreams[i].Name,
+			Port:         client.config.Upstreams[i].Port,
+			Kind:         client.config.Upstreams[i].Kind,
+			ScalingGroup: client.config.Upstreams[i].AutoscalingGroup,
+			MaxConns:     &client.config.Upstreams[i].MaxConns,
+			MaxFails:     &client.config.Upstreams[i].MaxFails,
+			FailTimeout:  client.config.Upstreams[i].FailTimeout,
+			SlowStart:    client.config.Upstreams[i].SlowStart,
 		}
 		upstreams = append(upstreams, u)
 	}
@@ -167,7 +167,7 @@ func (client *AWSClient) GetPrivateIPsForScalingGroup(name string) ([]string, er
 
 type awsConfig struct {
 	Region    string
-	Upstreams []awsUpstream
+	Upstreams []*awsUpstream
 }
 
 type awsUpstream struct {

--- a/cmd/sync/aws.go
+++ b/cmd/sync/aws.go
@@ -69,8 +69,8 @@ func (client *AWSClient) GetUpstreams() []Upstream {
 			ScalingGroup: client.config.Upstreams[i].AutoscalingGroup,
 			MaxConns:     &client.config.Upstreams[i].MaxConns,
 			MaxFails:     &client.config.Upstreams[i].MaxFails,
-			FailTimeout:  client.config.Upstreams[i].FailTimeout,
-			SlowStart:    client.config.Upstreams[i].SlowStart,
+			FailTimeout:  getFailTimeoutOrDefault(client.config.Upstreams[i].FailTimeout),
+			SlowStart:    getSlowStartOrDefault(client.config.Upstreams[i].SlowStart),
 		}
 		upstreams = append(upstreams, u)
 	}
@@ -167,7 +167,7 @@ func (client *AWSClient) GetPrivateIPsForScalingGroup(name string) ([]string, er
 
 type awsConfig struct {
 	Region    string
-	Upstreams []*awsUpstream
+	Upstreams []awsUpstream
 }
 
 type awsUpstream struct {

--- a/cmd/sync/aws_test.go
+++ b/cmd/sync/aws_test.go
@@ -8,7 +8,7 @@ type testInputAWS struct {
 }
 
 func getValidAWSConfig() *awsConfig {
-	upstreams := []awsUpstream{
+	upstreams := []*awsUpstream{
 		{
 			Name:             "backend1",
 			AutoscalingGroup: "backend-group",
@@ -88,4 +88,69 @@ func TestValidateAWSConfigValid(t *testing.T) {
 	if err != nil {
 		t.Errorf("validateAWSConfig() failed for the valid config: %v", err)
 	}
+}
+
+func TestGetUpstreamsAWS(t *testing.T) {
+	cfg := getValidAWSConfig()
+	var upstreams = []*awsUpstream{
+		{
+			Name: "127.0.0.1",
+			Port: 80,
+			MaxFails: 1,
+			MaxConns: 2,
+			SlowStart: "5s",
+			FailTimeout: "10s",
+		},
+		{
+			Name: "127.0.0.2",
+			Port: 80,
+			MaxFails: 2,
+			MaxConns: 3,
+			SlowStart: "6s",
+			FailTimeout: "11s",
+		},
+	}
+	cfg.Upstreams = upstreams
+	c := AWSClient{config: cfg}
+
+	ups := c.GetUpstreams()
+	for _, u := range ups {
+		found := false
+		for _, cfgU := range cfg.Upstreams {
+			if u.Name == cfgU.Name {
+				if !areEqualUpstreamsAWS(cfgU, u) {
+					t.Errorf("GetUpstreams() returned a wrong Upstream %+v for the configuration %+v", u, cfgU)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Upstream %+v not found in configuration.", u)
+		}
+	}
+}
+
+func areEqualUpstreamsAWS(u1 *awsUpstream, u2 Upstream) bool {
+	if u1.Port != u2.Port {
+		return false
+	}
+
+	if u1.FailTimeout != u2.FailTimeout {
+		return false
+	}
+
+	if u1.SlowStart != u2.SlowStart {
+		return false
+	}
+
+	if u1.MaxConns != *u2.MaxConns {
+		return false
+	}
+
+	if u1.MaxFails != *u2.MaxFails {
+		return false
+	}
+
+	return true
 }

--- a/cmd/sync/aws_test.go
+++ b/cmd/sync/aws_test.go
@@ -8,7 +8,7 @@ type testInputAWS struct {
 }
 
 func getValidAWSConfig() *awsConfig {
-	upstreams := []*awsUpstream{
+	upstreams := []awsUpstream{
 		{
 			Name:             "backend1",
 			AutoscalingGroup: "backend-group",
@@ -92,21 +92,21 @@ func TestValidateAWSConfigValid(t *testing.T) {
 
 func TestGetUpstreamsAWS(t *testing.T) {
 	cfg := getValidAWSConfig()
-	var upstreams = []*awsUpstream{
+	var upstreams = []awsUpstream{
 		{
-			Name: "127.0.0.1",
-			Port: 80,
-			MaxFails: 1,
-			MaxConns: 2,
-			SlowStart: "5s",
+			Name:        "127.0.0.1",
+			Port:        80,
+			MaxFails:    1,
+			MaxConns:    2,
+			SlowStart:   "5s",
 			FailTimeout: "10s",
 		},
 		{
-			Name: "127.0.0.2",
-			Port: 80,
-			MaxFails: 2,
-			MaxConns: 3,
-			SlowStart: "6s",
+			Name:        "127.0.0.2",
+			Port:        80,
+			MaxFails:    2,
+			MaxConns:    3,
+			SlowStart:   "6s",
 			FailTimeout: "11s",
 		},
 	}
@@ -131,7 +131,7 @@ func TestGetUpstreamsAWS(t *testing.T) {
 	}
 }
 
-func areEqualUpstreamsAWS(u1 *awsUpstream, u2 Upstream) bool {
+func areEqualUpstreamsAWS(u1 awsUpstream, u2 Upstream) bool {
 	if u1.Port != u2.Port {
 		return false
 	}

--- a/cmd/sync/azure.go
+++ b/cmd/sync/azure.go
@@ -130,16 +130,16 @@ func (client *AzureClient) configure() error {
 // GetUpstreams returns the Upstreams list
 func (client *AzureClient) GetUpstreams() []Upstream {
 	var upstreams []Upstream
-	for _, azureU := range client.config.Upstreams {
+	for i := 0; i < len(client.config.Upstreams); i++ {
 		u := Upstream{
-			Name:         azureU.Name,
-			Port:         azureU.Port,
-			Kind:         azureU.Kind,
-			ScalingGroup: azureU.VMScaleSet,
-			MaxConns:     &azureU.MaxConns,
-			MaxFails:     &azureU.MaxFails,
-			FailTimeout:  azureU.FailTimeout,
-			SlowStart:    azureU.SlowStart,
+			Name:         client.config.Upstreams[i].Name,
+			Port:         client.config.Upstreams[i].Port,
+			Kind:         client.config.Upstreams[i].Kind,
+			ScalingGroup: client.config.Upstreams[i].VMScaleSet,
+			MaxConns:     &client.config.Upstreams[i].MaxConns,
+			MaxFails:     &client.config.Upstreams[i].MaxFails,
+			FailTimeout:  client.config.Upstreams[i].FailTimeout,
+			SlowStart:    client.config.Upstreams[i].SlowStart,
 		}
 		upstreams = append(upstreams, u)
 	}
@@ -149,7 +149,7 @@ func (client *AzureClient) GetUpstreams() []Upstream {
 type azureConfig struct {
 	SubscriptionID    string `yaml:"subscription_id"`
 	ResourceGroupName string `yaml:"resource_group_name"`
-	Upstreams         []azureUpstream
+	Upstreams         []*azureUpstream
 }
 
 type azureUpstream struct {

--- a/cmd/sync/azure.go
+++ b/cmd/sync/azure.go
@@ -138,8 +138,8 @@ func (client *AzureClient) GetUpstreams() []Upstream {
 			ScalingGroup: client.config.Upstreams[i].VMScaleSet,
 			MaxConns:     &client.config.Upstreams[i].MaxConns,
 			MaxFails:     &client.config.Upstreams[i].MaxFails,
-			FailTimeout:  client.config.Upstreams[i].FailTimeout,
-			SlowStart:    client.config.Upstreams[i].SlowStart,
+			FailTimeout:  getFailTimeoutOrDefault(client.config.Upstreams[i].FailTimeout),
+			SlowStart:    getSlowStartOrDefault(client.config.Upstreams[i].SlowStart),
 		}
 		upstreams = append(upstreams, u)
 	}
@@ -149,7 +149,7 @@ func (client *AzureClient) GetUpstreams() []Upstream {
 type azureConfig struct {
 	SubscriptionID    string `yaml:"subscription_id"`
 	ResourceGroupName string `yaml:"resource_group_name"`
-	Upstreams         []*azureUpstream
+	Upstreams         []azureUpstream
 }
 
 type azureUpstream struct {

--- a/cmd/sync/azure_test.go
+++ b/cmd/sync/azure_test.go
@@ -12,7 +12,7 @@ type testInputAzure struct {
 }
 
 func getValidAzureConfig() *azureConfig {
-	upstreams := []*azureUpstream{
+	upstreams := []azureUpstream{
 		{
 			Name:       "backend1",
 			VMScaleSet: "backend-group",
@@ -159,21 +159,21 @@ func TestGetPrimaryIPFromInterfaceIPConfigurationFail(t *testing.T) {
 
 func TestGetUpstreamsAzure(t *testing.T) {
 	cfg := getValidAzureConfig()
-	var upstreams = []*azureUpstream{
+	var upstreams = []azureUpstream{
 		{
-			Name: "127.0.0.1",
-			Port: 80,
-			MaxFails: 1,
-			MaxConns: 2,
-			SlowStart: "5s",
+			Name:        "127.0.0.1",
+			Port:        80,
+			MaxFails:    1,
+			MaxConns:    2,
+			SlowStart:   "5s",
 			FailTimeout: "10s",
 		},
 		{
-			Name: "127.0.0.2",
-			Port: 80,
-			MaxFails: 2,
-			MaxConns: 3,
-			SlowStart: "6s",
+			Name:        "127.0.0.2",
+			Port:        80,
+			MaxFails:    2,
+			MaxConns:    3,
+			SlowStart:   "6s",
 			FailTimeout: "11s",
 		},
 	}
@@ -198,7 +198,7 @@ func TestGetUpstreamsAzure(t *testing.T) {
 	}
 }
 
-func areEqualUpstreamsAzure(u1 *azureUpstream, u2 Upstream) bool {
+func areEqualUpstreamsAzure(u1 azureUpstream, u2 Upstream) bool {
 	if u1.Port != u2.Port {
 		return false
 	}

--- a/cmd/sync/parameters.go
+++ b/cmd/sync/parameters.go
@@ -1,0 +1,20 @@
+package main
+
+const defaultFailTimeout = "10s"
+const defaultSlowStart = "0s"
+
+func getFailTimeoutOrDefault(failTimeout string) string {
+	if failTimeout == "" {
+		return defaultFailTimeout
+	}
+
+	return failTimeout
+}
+
+func getSlowStartOrDefault(slowStart string) string {
+	if slowStart == "" {
+		return defaultSlowStart
+	}
+
+	return slowStart
+}

--- a/cmd/sync/parameters_test.go
+++ b/cmd/sync/parameters_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGetFailTimeoutOrDefault(t *testing.T) {
+	tests := []struct{
+		input string
+		expected string
+	}{
+		{
+			input: "",
+			expected: defaultFailTimeout,
+		},
+		{
+			input: "10s",
+			expected: "10s",
+		},
+	}
+
+	for _, test := range tests {
+		result := getFailTimeoutOrDefault(test.input)
+		if result != test.expected {
+			t.Errorf("getFailTimeoutOrDefault(%v) returned %v but expected %v", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestGetSlowStartOrDefault(t *testing.T) {
+	tests := []struct{
+		input string
+		expected string
+	}{
+		{
+			input: "",
+			expected: defaultSlowStart,
+		},
+		{
+			input: "10s",
+			expected: "10s",
+		},
+	}
+
+	for _, test := range tests {
+		result := getSlowStartOrDefault(test.input)
+		if result != test.expected {
+			t.Errorf("getSlowStartOrDefault(%v) returned %v but expected %v", test.input, result, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
### Proposed changes
Bug raised by @tellet 

There was an issue in the Upstreams, changed to pointer to keep the values from the config struct instead.
