### PR TITLE
Test new ignore feature in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,26 +3,28 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
-      - "ciarams87"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
+    ignore:
+      - dependency-name: "*/aws-sdk-go"
+        update-types: ["version-update:semver-patch"]
     reviewers:
       - "nginxinc/kic"
   - package-ecosystem: "docker"
     directory: "/build"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
   - package-ecosystem: "pip"
     directory: "/tests"
     schedule:
-      interval: weekly
+      interval: daily
     reviewers:
       - "nginxinc/kic"
       - "vepatel"


### PR DESCRIPTION
New beta feature for ignoring updates, in this case, all patch versions of `aws-sdk-go`.