### PR TITLE
Add revive linter with recommended config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,33 @@
 linters-settings:
   misspell:
     locale: US
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
 
 linters:
     enable:
@@ -20,6 +47,7 @@ linters:
     - nilerr
     - noctx
     - predeclared
+    - revive
     - staticcheck
     - structcheck
     - typecheck


### PR DESCRIPTION
Adding `revive` (replacement for the deprecated `golint`) with the [recommended](https://github.com/mgechev/revive#recommended-configuration) configuration