### PR TITLE
Use GitHub cache backend API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+      - name: Determine Go version from go.mod
+        run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
       - name: Setup Golang Environment
         uses: actions/setup-go@v2
         with:
@@ -71,15 +73,6 @@ jobs:
           key: nginx-asg-sync-${{ github.run_id }}-${{ github.run_number }}
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Build Image Amazon 1
         uses: docker/build-push-action@v2
         with:
@@ -87,8 +80,8 @@ jobs:
           context: '.'
           target: local
           load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: amazon-builder:${{ github.sha }}
           build-args: |
             CONTAINER_VERSION=amazonlinux:1
@@ -106,8 +99,8 @@ jobs:
           context: '.'
           target: local
           load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: amazon2-builder:${{ github.sha }}
           build-args: |
             CONTAINER_VERSION=amazonlinux:2
@@ -125,8 +118,8 @@ jobs:
           context: '.'
           target: local
           load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: centos7-builder:${{ github.sha }}
           build-args: |
             CONTAINER_VERSION=centos:7
@@ -144,8 +137,8 @@ jobs:
           context: '.'
           target: local
           load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: centos8-builder:${{ github.sha }}
           build-args: |
             CONTAINER_VERSION=centos:8
@@ -163,8 +156,8 @@ jobs:
           context: '.'
           target: local
           load: true
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: debian-builder:${{ github.sha }}
           build-args: |
             OS_TYPE=deb_based


### PR DESCRIPTION
Use the new GHA [cache](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api) removing the need for an additional action

Also note that the cache wasn't used properly so the layers weren't retrieved from the cache.
