### PR TITLE
Remove minor version for cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build Binary
         run: make build
       - name: Store Artifacts in Cache
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/nginx-asg-sync
           key: nginx-asg-sync-${{ github.run_id }}-${{ github.run_number }}
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Fetch Cached Artifacts
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/nginx-asg-sync
           key: nginx-asg-sync-${{ github.run_id }}-${{ github.run_number }}


### PR DESCRIPTION
There no need for us to pinpoint a specific version of the cache action, other than the major version. This will also reduce the PRs from dependabot.