### PR TITLE
Update ignored versions in dependabot and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     ignore:
       - dependency-name: "*/aws-sdk-go"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "boto3"
+        update-types: ["version-update:semver-patch"]
     reviewers:
       - "nginxinc/kic"
   - package-ecosystem: "docker"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,13 +6,11 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-20.04
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1.3.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"
         env:


### PR DESCRIPTION
- Ignores patch versions of `boto3` to reduce the number of PRs
- Updates action to use the user as suggested in the docs https://github.com/dependabot/fetch-metadata#enabling-auto-merge
