### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache: true
       - name: Determine GOPATH
         id: go
-        run: echo "::set-output name=go_path::$(go env GOPATH)"
+        run: echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
       - name: Build binary
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -72,7 +72,7 @@ jobs:
           cache: true
       - name: Determine GOPATH
         id: go
-        run: echo "::set-output name=go_path::$(go env GOPATH)"
+        run: echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
       - name: Publish Release Notes
         uses: release-drafter/release-drafter@v5
         with:


### PR DESCRIPTION
### Proposed changes

Resolve #310 

Update `.github/workflows/ci.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo "::set-output name=go_path::$(go env GOPATH)"
```

**TO-BE**

```yml
run: echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-asg-sync/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
