### PR TITLE
Use latest stable version of Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Determine GOPATH
         id: go
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Run Tests
         run: make test
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Determine GOPATH
         id: go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
         if: matrix.language == 'go'
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Lint Code
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0


### PR DESCRIPTION
### Proposed changes

Since Go changed the versioning in `go.mod` to specify a patch release, we don't use the latest go version when building the binary.
Before with `1.20` in `go.mod` we would use the latest version of `1.20.x`, but now since we specify `1.21.3` in `go.mod` we use that fixed version and not `1.21.4` for example, and future updates.
`1.21.3` in `go.mod` should be considered a minimum requirement.
